### PR TITLE
remove "import" comments

### DIFF
--- a/windows/ansi_reader.go
+++ b/windows/ansi_reader.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package windowsconsole // import "github.com/moby/term/windows"
+package windowsconsole
 
 import (
 	"bytes"

--- a/windows/ansi_writer.go
+++ b/windows/ansi_writer.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package windowsconsole // import "github.com/moby/term/windows"
+package windowsconsole
 
 import (
 	"io"

--- a/windows/console.go
+++ b/windows/console.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package windowsconsole // import "github.com/moby/term/windows"
+package windowsconsole
 
 import (
 	"os"

--- a/windows/doc.go
+++ b/windows/doc.go
@@ -2,4 +2,4 @@
 // When asked for the set of standard streams (e.g., stdin, stdout, stderr), the code will create
 // and return pseudo-streams that convert ANSI sequences to / from Windows Console API calls.
 
-package windowsconsole // import "github.com/moby/term/windows"
+package windowsconsole


### PR DESCRIPTION
follow-up to https://github.com/moby/term/pull/5 - I'll rebase once that's merged


These comments were originally in place for the moby/moby repository,
which should be imported as docker/docker. That's not an issue in this
repository, so we can remove these import comments.