### PR TITLE
cleanup gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,24 +1,8 @@
-# Docker project generated files to ignore
-#  if you want to ignore files created by your editor/tools,
-#  please consider a global .gitignore https://help.github.com/articles/ignoring-files
-*.exe
-*.exe~
-*.gz
-*.orig
-test.main
-.*.swp
-.DS_Store
-# a .bashrc may be added to customize the build environment
-.bashrc
-.editorconfig
-.gopath/
-.go-pkg-cache/
-.idea/
-autogen/
-bundles/
-cmd/dockerd/dockerd
-contrib/builder/rpm/*/changelog
-vendor/pkg/
-go-test-report.json
+# if you want to ignore files created by your editor/tools, consider using a
+# global .gitignore or .git/info/exclude see https://help.github.com/articles/ignoring-files
+.*
+!.github
+!.gitignore
 profile.out
-junit-report.xml
+# support running go modules in vendor mode for local development
+vendor/


### PR DESCRIPTION
supersedes / replaces https://github.com/moby/term/pull/3
closes https://github.com/moby/term/pull/3

- Update the header to not reference "Docker", and with
  additional options for ignoring custom files.
- Ignore all dot-files, except for .gitignore and .github/
- I kept / added `vendor/` to the gitignore, as it allows
  using a vendor director locally for development/testing.
