### PR TITLE
Fix build for windows/386 platform

### DIFF
--- a/term_windows.go
+++ b/term_windows.go
@@ -71,19 +71,19 @@ func StdStreams() (stdIn io.ReadCloser, stdOut, stdErr io.Writer) {
 	// go-ansiterm hasn't switch to x/sys/windows.
 	// TODO: switch back to x/sys/windows once go-ansiterm has switched
 	if emulateStdin {
-		stdIn = windowsconsole.NewAnsiReader(windows.STD_INPUT_HANDLE)
+		stdIn = windowsconsole.NewAnsiReader(int64(windows.STD_INPUT_HANDLE)) // nolint: unconvert
 	} else {
 		stdIn = os.Stdin
 	}
 
 	if emulateStdout {
-		stdOut = windowsconsole.NewAnsiWriter(windows.STD_OUTPUT_HANDLE)
+		stdOut = windowsconsole.NewAnsiWriter(int64(windows.STD_OUTPUT_HANDLE)) // nolint: unconvert
 	} else {
 		stdOut = os.Stdout
 	}
 
 	if emulateStderr {
-		stdErr = windowsconsole.NewAnsiWriter(windows.STD_ERROR_HANDLE)
+		stdErr = windowsconsole.NewAnsiWriter(int64(windows.STD_ERROR_HANDLE)) // nolint: unconvert
 	} else {
 		stdErr = os.Stderr
 	}

--- a/windows/ansi_reader.go
+++ b/windows/ansi_reader.go
@@ -30,8 +30,8 @@ type ansiReader struct {
 
 // NewAnsiReader returns an io.ReadCloser that provides VT100 terminal emulation on top of a
 // Windows console input handle.
-func NewAnsiReader(nFile int) io.ReadCloser {
-	file, fd := winterm.GetStdFile(nFile)
+func NewAnsiReader(nFile int64) io.ReadCloser {
+	file, fd := winterm.GetStdFile(int(nFile))
 	return &ansiReader{
 		file:    file,
 		fd:      fd,

--- a/windows/ansi_writer.go
+++ b/windows/ansi_writer.go
@@ -23,8 +23,8 @@ type ansiWriter struct {
 
 // NewAnsiWriter returns an io.Writer that provides VT100 terminal emulation on top of a
 // Windows console output handle.
-func NewAnsiWriter(nFile int) io.Writer {
-	file, fd := winterm.GetStdFile(nFile)
+func NewAnsiWriter(nFile int64) io.Writer {
+	file, fd := winterm.GetStdFile(int(nFile))
 	info, err := winterm.GetConsoleScreenBufferInfo(fd)
 	if err != nil {
 		return nil


### PR DESCRIPTION
Before this patch, the build on 32bit windows would fail with:

```
> GOOS=windows GOARCH=386 go build ./...
./term_windows.go:74:39: constant 4294967286 overflows int
./term_windows.go:80:40: constant 4294967285 overflows int
./term_windows.go:86:40: constant 4294967284 overflows int
```

We now cast the values to int64 to avoid this error.
