### PR TITLE
CI: remove "sudo" to fix incorrect Go versions (incorrect PATH, GOROOT)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,8 +19,6 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - name: Install Go
-        uses: actions/setup-go@v1
       - name: Checkout code
         uses: actions/checkout@v2
       - name: Lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v2
     - name: Test
-      run: sudo go test -v ./...
+      run: go test -v ./...
   lint:
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
We were using `sudo` (without `-E`), causing environment variables that were set by `actions/setup-go` to be lost.

We need to preserve environment variables, including `PATH`, because `actions/setup-go@v2` installs Go in specific paths to allow multiple versions to be installed/cached on workers, for example, in `"/opt/hostedtoolcache/go/1.13.15/x64"`.

While it's possible to fix by adding both `-E`, and `env "PATH=$PATH"` (sudo -E does not preserve `PATH`as a security measure (see https://unix.stackexchange.com/a/83194/78656), this repository does not need `sudo` for its tests to run, so we might as well remove it altogether.

Also removing the setup-go step from the `Lint` stage, as it runs in a container, so Go is not needed on the host.

For details, see my debugging steps in https://github.com/moby/term/pull/21
