### PR TITLE
update godoc, as golang.org/x/crypto/ssh/terminal is deprecated

### DIFF
--- a/windows/console.go
+++ b/windows/console.go
@@ -29,7 +29,7 @@ func GetHandleInfo(in interface{}) (uintptr, bool) {
 
 // IsConsole returns true if the given file descriptor is a Windows Console.
 // The code assumes that GetConsoleMode will return an error for file descriptors that are not a console.
-// Deprecated: use golang.org/x/sys/windows.GetConsoleMode() or golang.org/x/crypto/ssh/terminal.IsTerminal()
+// Deprecated: use golang.org/x/sys/windows.GetConsoleMode() or golang.org/x/term.IsTerminal()
 var IsConsole = isConsole
 
 func isConsole(fd uintptr) bool {


### PR DESCRIPTION
relates to https://github.com/golang/go/issues/31044 / https://github.com/golang/crypto/commit/4be66e5b658251a93e17d931a68d9c0ecba9f83a