### PR TITLE
Upgraded version of Azure/go-ansiterm

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/moby/term
 go 1.13
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78
+	github.com/Azure/go-ansiterm v0.0.0-20210608035416-43c61cb656b4
 	github.com/creack/pty v1.1.11
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/moby/term
 go 1.13
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20210608035416-43c61cb656b4
+	github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795
 	github.com/creack/pty v1.1.11
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/go-ansiterm v0.0.0-20210608035416-43c61cb656b4 h1:poX3j1kSFMgZhtUGrKSAwjh/FKVYrzvoXzwyXPHkAv0=
-github.com/Azure/go-ansiterm v0.0.0-20210608035416-43c61cb656b4/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795 h1:q4kDoSrHgRoD6okimjwWJOVKyxEUNS2JIuwt+EqcIqQ=
+github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,5 @@
-github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
-github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
+github.com/Azure/go-ansiterm v0.0.0-20210608035416-43c61cb656b4 h1:poX3j1kSFMgZhtUGrKSAwjh/FKVYrzvoXzwyXPHkAv0=
+github.com/Azure/go-ansiterm v0.0.0-20210608035416-43c61cb656b4/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
Upgraded version of Azure/go-ansiterm from `v0.0.0-20170929234023-d6e3b3328b78` to` v0.0.0-20210608035416-43c61cb656b4` which fixes issue https://github.com/moby/term/issues/26, https://github.com/kubernetes/kubernetes/issues/102404 and https://github.com/docker/for-win/issues/9770

Latest version of go-ansiterm is compatible with the stdin, stdout and stderr flags passed to `winterm.GetStdFile`  function from package `golang.org/x/sys/windows` and it's also backwards compatible with `syscall` package as well