### PR TITLE
Move the ansi implementation to a separate module.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/moby/term
 go 1.13
 
 require (
-	github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795
 	github.com/creack/pty v1.1.11
 	github.com/google/go-cmp v0.4.0
 	github.com/pkg/errors v0.9.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,5 +1,3 @@
-github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795 h1:q4kDoSrHgRoD6okimjwWJOVKyxEUNS2JIuwt+EqcIqQ=
-github.com/Azure/go-ansiterm v0.0.0-20210608223527-2377c96fe795/go.mod h1:LmzpDX56iTiv29bbRTIsUNlaFfuhWRQBWjQdVyAevI8=
 github.com/creack/pty v1.1.11 h1:07n33Z8lZxZ2qwegKbObQohDhXDQxiMMz1NOUGYlesw=
 github.com/creack/pty v1.1.11/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/windows/console.go
+++ b/windows/console.go
@@ -8,19 +8,16 @@ import (
 	"golang.org/x/sys/windows"
 )
 
+type fd interface {
+	Fd() uintptr
+}
+
 // GetHandleInfo returns file descriptor and bool indicating whether the file is a console.
 func GetHandleInfo(in interface{}) (uintptr, bool) {
-	switch t := in.(type) {
-	case *ansiReader:
-		return t.Fd(), true
-	case *ansiWriter:
-		return t.Fd(), true
-	}
-
 	var inFd uintptr
 	var isTerminal bool
 
-	if file, ok := in.(*os.File); ok {
+	if file, ok := in.(fd); ok {
 		inFd = file.Fd()
 		isTerminal = isConsole(inFd)
 	}

--- a/windows/legacyconsole/ansi_reader.go
+++ b/windows/legacyconsole/ansi_reader.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package windowsconsole
+package legacyconsole
 
 import (
 	"bytes"

--- a/windows/legacyconsole/ansi_writer.go
+++ b/windows/legacyconsole/ansi_writer.go
@@ -1,6 +1,6 @@
 // +build windows
 
-package windowsconsole
+package legacyconsole
 
 import (
 	"io"

--- a/windows/legacyconsole/doc.go
+++ b/windows/legacyconsole/doc.go
@@ -1,0 +1,8 @@
+/*
+package legacyconsole can be used to interact with the legacy terminal mode in Windows (pre-Win10).
+
+This package is included for historical reasons and is separate from the rest of the repo in order
+keep depdencies separate since go-ansiterm is maintained on a best-effort basis.
+*/
+
+package legacyconsole

--- a/windows/legacyconsole/go.mod
+++ b/windows/legacyconsole/go.mod
@@ -1,0 +1,5 @@
+module github.com/moby/term/windows/legacyconsole
+
+go 1.16
+
+require github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1

--- a/windows/legacyconsole/go.sum
+++ b/windows/legacyconsole/go.sum
@@ -1,0 +1,4 @@
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1 h1:UQHMgLO+TxOElx5B5HZ4hJQsoJ/PvUvKRhJHDQXO8P8=
+github.com/Azure/go-ansiterm v0.0.0-20210617225240-d185dfc1b5a1/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22 h1:RqytpXGR1iVNX7psjB3ff8y7sNFinVFvkx1c8SjBkio=
+golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=


### PR DESCRIPTION
This cuts down deps on the main module.