### PR TITLE
term: remove interrupt handler on termios

### DIFF
--- a/term.go
+++ b/term.go
@@ -6,10 +6,8 @@ package term
 
 import (
 	"errors"
-	"fmt"
 	"io"
 	"os"
-	"os/signal"
 
 	"golang.org/x/sys/unix"
 )
@@ -81,7 +79,6 @@ func DisableEcho(fd uintptr, state *State) error {
 	if err := tcset(fd, &newState); err != nil {
 		return err
 	}
-	handleInterrupt(fd, state)
 	return nil
 }
 
@@ -93,7 +90,6 @@ func SetRawTerminal(fd uintptr) (*State, error) {
 	if err != nil {
 		return nil, err
 	}
-	handleInterrupt(fd, oldState)
 	return oldState, err
 }
 
@@ -102,19 +98,4 @@ func SetRawTerminal(fd uintptr) (*State, error) {
 // state. On Windows, it disables LF -> CRLF translation.
 func SetRawTerminalOutput(fd uintptr) (*State, error) {
 	return nil, nil
-}
-
-func handleInterrupt(fd uintptr, state *State) {
-	sigchan := make(chan os.Signal, 1)
-	signal.Notify(sigchan, os.Interrupt)
-	go func() {
-		for range sigchan {
-			// quit cleanly and the new terminal item is on a new line
-			fmt.Println()
-			signal.Stop(sigchan)
-			close(sigchan)
-			RestoreTerminal(fd, state)
-			os.Exit(1)
-		}
-	}()
 }


### PR DESCRIPTION
On termios platforms, interrupt signals are not generated in raw mode terminals as the ISIG setting is not enabled. Remove interrupt handler as it does nothing for raw mode and prevents other uses of INT signal with this library.

This code seems to go back all the way to moby/moby#214 where signal handling was improved for monolithic docker repository. Raw mode -ISIG got reintroduced in moby/moby@3f63b878076, but the INT handler was left behind.

Signed-off-by: Sami Loone <sloone@forcepoint.com>