### PR TITLE
switch to use blackbox testing, move tests to separate module

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,7 @@ jobs:
       with:
         persist-credentials: false
     - name: Test
-      run: go test -v ./...
+      run: cd test && go test -v .
   lint:
     runs-on: ubuntu-latest
     steps:
@@ -49,4 +49,10 @@ jobs:
           docker run --rm \
             -v ./:/go/src/github.com/moby/term \
             -w /go/src/github.com/moby/term \
+            golangci/golangci-lint:v2.11-alpine golangci-lint run -v
+      - name: Lint tests
+        run: |
+          docker run --rm \
+            -v ./:/go/src/github.com/moby/term \
+            -w /go/src/github.com/moby/term/test \
             golangci/golangci-lint:v2.11-alpine golangci-lint run -v

--- a/ascii_test.go
+++ b/ascii_test.go
@@ -1,12 +1,14 @@
-package term
+package term_test
 
 import (
 	"bytes"
 	"testing"
+
+	"github.com/moby/term"
 )
 
 func TestToBytes(t *testing.T) {
-	codes, err := ToBytes("ctrl-a,a")
+	codes, err := term.ToBytes("ctrl-a,a")
 	if err != nil {
 		t.Error(err)
 	}
@@ -15,12 +17,12 @@ func TestToBytes(t *testing.T) {
 		t.Errorf("expected: %+v, got: %+v", expected, codes)
 	}
 
-	_, err = ToBytes("shift-z")
+	_, err = term.ToBytes("shift-z")
 	if err == nil {
 		t.Error("expected and error")
 	}
 
-	codes, err = ToBytes("ctrl-@,ctrl-[,~,ctrl-o")
+	codes, err = term.ToBytes("ctrl-@,ctrl-[,~,ctrl-o")
 	if err != nil {
 		t.Error(err)
 	}
@@ -29,7 +31,7 @@ func TestToBytes(t *testing.T) {
 		t.Errorf("expected: %+v, got: %+v", expected, codes)
 	}
 
-	codes, err = ToBytes("DEL,+")
+	codes, err = term.ToBytes("DEL,+")
 	if err != nil {
 		t.Error(err)
 	}

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,5 @@ go 1.18
 
 require (
 	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c
-	github.com/creack/pty v1.1.18
 	golang.org/x/sys v0.1.0
 )

--- a/test/go.mod
+++ b/test/go.mod
@@ -1,0 +1,15 @@
+module github.com/moby/term/test
+
+go 1.18
+
+require (
+	github.com/creack/pty v1.1.18
+	github.com/moby/term v0.0.0-00010101000000-000000000000 // replaced
+)
+
+require (
+	github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c // indirect
+	golang.org/x/sys v0.1.0 // indirect
+)
+
+replace github.com/moby/term => ../

--- a/test/go.sum
+++ b/test/go.sum
@@ -1,5 +1,7 @@
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/creack/pty v1.1.18 h1:n56/Zwd5o6whRC5PMGretI4IdRLlmBXYNjScPaBgsbY=
+github.com/creack/pty v1.1.18/go.mod h1:MOBLtS5ELjhRRrroQr9kyvTxUAFNvYEK993ew/Vr4O4=
 golang.org/x/sys v0.0.0-20210616094352-59db8d763f22/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.1.0 h1:kunALQeHf1/185U1i0GOB/fy1IPRDDpuoOOqRReG57U=
 golang.org/x/sys v0.1.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/test/proxy_test.go
+++ b/test/proxy_test.go
@@ -1,15 +1,17 @@
-package term
+package test
 
 import (
 	"bytes"
 	"testing"
+
+	"github.com/moby/term"
 )
 
 func TestEscapeProxyRead(t *testing.T) {
 	t.Run("no escape keys, keys [a]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("")
-		keys, _ := ToBytes("a")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("")
+		keys, _ := term.ToBytes("a")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, len(keys))
 		nr, err := reader.Read(buf)
@@ -25,9 +27,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("no escape keys, keys [a,b,c]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("")
-		keys, _ := ToBytes("a,b,c")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("")
+		keys, _ := term.ToBytes("a,b,c")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, len(keys))
 		nr, err := reader.Read(buf)
@@ -43,9 +45,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("no escape keys, no keys", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("")
-		keys, _ := ToBytes("")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("")
+		keys, _ := term.ToBytes("")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, len(keys))
 		nr, err := reader.Read(buf)
@@ -64,9 +66,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("DEL escape key, keys [a,b,c,+]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("DEL")
-		keys, _ := ToBytes("a,b,c,+")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("DEL")
+		keys, _ := term.ToBytes("a,b,c,+")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, len(keys))
 		nr, err := reader.Read(buf)
@@ -82,9 +84,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("DEL escape key, no keys", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("DEL")
-		keys, _ := ToBytes("")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("DEL")
+		keys, _ := term.ToBytes("")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, len(keys))
 		nr, err := reader.Read(buf)
@@ -103,9 +105,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("ctrl-x,ctrl-@ escape key, keys [DEL]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("ctrl-x,ctrl-@")
-		keys, _ := ToBytes("DEL")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("ctrl-x,ctrl-@")
+		keys, _ := term.ToBytes("DEL")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, len(keys))
 		nr, err := reader.Read(buf)
@@ -121,9 +123,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("ctrl-c escape key, keys [ctrl-c]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("ctrl-c")
-		keys, _ := ToBytes("ctrl-c")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("ctrl-c")
+		keys, _ := term.ToBytes("ctrl-c")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, len(keys))
 		nr, err := reader.Read(buf)
@@ -139,9 +141,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("ctrl-c,ctrl-z escape key, keys [ctrl-c],[ctrl-z]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("ctrl-c,ctrl-z")
-		keys, _ := ToBytes("ctrl-c,ctrl-z")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("ctrl-c,ctrl-z")
+		keys, _ := term.ToBytes("ctrl-c,ctrl-z")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, 1)
 		nr, err := reader.Read(buf)
@@ -168,9 +170,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("ctrl-c,ctrl-z escape key, keys [ctrl-c,ctrl-z]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("ctrl-c,ctrl-z")
-		keys, _ := ToBytes("ctrl-c,ctrl-z")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("ctrl-c,ctrl-z")
+		keys, _ := term.ToBytes("ctrl-c,ctrl-z")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, 2)
 		nr, err := reader.Read(buf)
@@ -186,9 +188,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("ctrl-c,ctrl-z escape key, keys [ctrl-c],[DEL,+]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("ctrl-c,ctrl-z")
-		keys, _ := ToBytes("ctrl-c,DEL,+")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("ctrl-c,ctrl-z")
+		keys, _ := term.ToBytes("ctrl-c,DEL,+")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, 1)
 		nr, err := reader.Read(buf)
@@ -216,9 +218,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("ctrl-c,ctrl-z escape key, keys [ctrl-c],[DEL]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("ctrl-c,ctrl-z")
-		keys, _ := ToBytes("ctrl-c,DEL")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("ctrl-c,ctrl-z")
+		keys, _ := term.ToBytes("ctrl-c,DEL")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, 1)
 		nr, err := reader.Read(buf)
@@ -246,9 +248,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("a,b,c,d escape key, keys [a,b],[c,d]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("a,b,c,d")
-		keys, _ := ToBytes("a,b,c,d")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("a,b,c,d")
+		keys, _ := term.ToBytes("a,b,c,d")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, 2)
 		nr, err := reader.Read(buf)
@@ -276,9 +278,9 @@ func TestEscapeProxyRead(t *testing.T) {
 	})
 
 	t.Run("ctrl-p,ctrl-q escape key, keys [ctrl-p],[a],[ctrl-p,ctrl-q]", func(t *testing.T) {
-		escapeKeys, _ := ToBytes("ctrl-p,ctrl-q")
-		keys, _ := ToBytes("ctrl-p,a,ctrl-p,ctrl-q")
-		reader := NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
+		escapeKeys, _ := term.ToBytes("ctrl-p,ctrl-q")
+		keys, _ := term.ToBytes("ctrl-p,a,ctrl-p,ctrl-q")
+		reader := term.NewEscapeProxy(bytes.NewReader(keys), escapeKeys)
 
 		buf := make([]byte, 1)
 		nr, err := reader.Read(buf)

--- a/test/term_test.go
+++ b/test/term_test.go
@@ -1,7 +1,7 @@
 //go:build !windows
 // +build !windows
 
-package term
+package test
 
 import (
 	"os"
@@ -9,6 +9,7 @@ import (
 	"testing"
 
 	cpty "github.com/creack/pty"
+	"github.com/moby/term"
 )
 
 func newTTYForTest(t *testing.T) *os.File {
@@ -39,7 +40,7 @@ func newTempFile(t *testing.T) *os.File {
 
 func TestGetWinsize(t *testing.T) {
 	tty := newTTYForTest(t)
-	winSize, err := GetWinsize(tty.Fd())
+	winSize, err := term.GetWinsize(tty.Fd())
 	if err != nil {
 		t.Error(err)
 	}
@@ -47,12 +48,12 @@ func TestGetWinsize(t *testing.T) {
 		t.Fatal("winSize is nil")
 	}
 
-	newSize := Winsize{Width: 200, Height: 200, x: winSize.x, y: winSize.y}
-	err = SetWinsize(tty.Fd(), &newSize)
+	newSize := term.Winsize{Width: 200, Height: 200}
+	err = term.SetWinsize(tty.Fd(), &newSize)
 	if err != nil {
 		t.Fatal(err)
 	}
-	winSize, err = GetWinsize(tty.Fd())
+	winSize, err = term.GetWinsize(tty.Fd())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -63,19 +64,19 @@ func TestGetWinsize(t *testing.T) {
 
 func TestSetWinsize(t *testing.T) {
 	tty := newTTYForTest(t)
-	winSize, err := GetWinsize(tty.Fd())
+	winSize, err := term.GetWinsize(tty.Fd())
 	if err != nil {
 		t.Fatal(err)
 	}
 	if winSize == nil {
 		t.Fatal("winSize is nil")
 	}
-	newSize := Winsize{Width: 200, Height: 200, x: winSize.x, y: winSize.y}
-	err = SetWinsize(tty.Fd(), &newSize)
+	newSize := term.Winsize{Width: 200, Height: 200}
+	err = term.SetWinsize(tty.Fd(), &newSize)
 	if err != nil {
 		t.Fatal(err)
 	}
-	winSize, err = GetWinsize(tty.Fd())
+	winSize, err = term.GetWinsize(tty.Fd())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -86,7 +87,7 @@ func TestSetWinsize(t *testing.T) {
 
 func TestGetFdInfo(t *testing.T) {
 	tty := newTTYForTest(t)
-	inFd, isTerm := GetFdInfo(tty)
+	inFd, isTerm := term.GetFdInfo(tty)
 	if inFd != tty.Fd() {
 		t.Errorf("expected: %d, got: %d", tty.Fd(), inFd)
 	}
@@ -94,7 +95,7 @@ func TestGetFdInfo(t *testing.T) {
 		t.Error("expected file-descriptor to be a terminal")
 	}
 	tmpFile := newTempFile(t)
-	inFd, isTerm = GetFdInfo(tmpFile)
+	inFd, isTerm = term.GetFdInfo(tmpFile)
 	if inFd != tmpFile.Fd() {
 		t.Errorf("expected: %d, got: %d", tty.Fd(), inFd)
 	}
@@ -105,12 +106,12 @@ func TestGetFdInfo(t *testing.T) {
 
 func TestIsTerminal(t *testing.T) {
 	tty := newTTYForTest(t)
-	isTerm := IsTerminal(tty.Fd())
+	isTerm := term.IsTerminal(tty.Fd())
 	if !isTerm {
 		t.Error("expected file-descriptor to be a terminal")
 	}
 	tmpFile := newTempFile(t)
-	isTerm = IsTerminal(tmpFile.Fd())
+	isTerm = term.IsTerminal(tmpFile.Fd())
 	if isTerm {
 		t.Error("expected file-descriptor to not be a terminal")
 	}
@@ -118,7 +119,7 @@ func TestIsTerminal(t *testing.T) {
 
 func TestSaveState(t *testing.T) {
 	tty := newTTYForTest(t)
-	state, err := SaveState(tty.Fd())
+	state, err := term.SaveState(tty.Fd())
 	if err != nil {
 		t.Error(err)
 	}
@@ -126,7 +127,7 @@ func TestSaveState(t *testing.T) {
 		t.Fatal("state is nil")
 	}
 	tty = newTTYForTest(t)
-	err = RestoreTerminal(tty.Fd(), state)
+	err = term.RestoreTerminal(tty.Fd(), state)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -134,9 +135,9 @@ func TestSaveState(t *testing.T) {
 
 func TestDisableEcho(t *testing.T) {
 	tty := newTTYForTest(t)
-	state, err := SetRawTerminal(tty.Fd())
+	state, err := term.SetRawTerminal(tty.Fd())
 	defer func() {
-		if err := RestoreTerminal(tty.Fd(), state); err != nil {
+		if err := term.RestoreTerminal(tty.Fd(), state); err != nil {
 			t.Error(err)
 		}
 	}()
@@ -146,7 +147,7 @@ func TestDisableEcho(t *testing.T) {
 	if state == nil {
 		t.Fatal("state is nil")
 	}
-	err = DisableEcho(tty.Fd(), state)
+	err = term.DisableEcho(tty.Fd(), state)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
This allows us to remove the test-dependencies from the module itself.

- [x] depends on https://github.com/moby/term/pull/33
- [x] depends on https://github.com/moby/term/pull/21
- [x] depends on https://github.com/moby/term/pull/34