### PR TITLE
windows: IsConsole(): fix deprecation comment

### DIFF
--- a/windows/console.go
+++ b/windows/console.go
@@ -30,8 +30,11 @@ func GetHandleInfo(in interface{}) (uintptr, bool) {
 
 // IsConsole returns true if the given file descriptor is a Windows Console.
 // The code assumes that GetConsoleMode will return an error for file descriptors that are not a console.
-// Deprecated: use golang.org/x/sys/windows.GetConsoleMode() or golang.org/x/term.IsTerminal()
-var IsConsole = isConsole
+//
+// Deprecated: use [windows.GetConsoleMode] or [golang.org/x/term.IsTerminal].
+func IsConsole(fd uintptr) bool {
+	return isConsole(fd)
+}
 
 func isConsole(fd uintptr) bool {
 	var mode uint32


### PR DESCRIPTION
- relates to https://github.com/moby/term/pull/10

This function was deprecated in 57a2131dd69588daf506fde11b5c51ac6e271025 (https://github.com/moby/term/pull/10), but the comment was not formatted correctly, causing it to not be documented as deprecated on pkg.go.dev.

Also changing this back to an actual function wrapper, so that it doesn't get documented in the "Variables" section.