### PR TITLE
windows: keyToString(): fix string conversion

### DIFF
--- a/windows/ansi_reader.go
+++ b/windows/ansi_reader.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"strconv"
 	"strings"
 	"unsafe"
 
@@ -195,10 +196,10 @@ func keyToString(keyEvent *winterm.KEY_EVENT_RECORD, escapeSequence []byte) stri
 
 	// <Alt>+Key generates ESC N Key
 	if !control && alt {
-		return ansiterm.KEY_ESC_N + strings.ToLower(string(keyEvent.UnicodeChar))
+		return ansiterm.KEY_ESC_N + strings.ToLower(strconv.Itoa(int(keyEvent.UnicodeChar)))
 	}
 
-	return string(keyEvent.UnicodeChar)
+	return strconv.Itoa(int(keyEvent.UnicodeChar))
 }
 
 // formatVirtualKey converts a virtual key (e.g., up arrow) into the appropriate ANSI string.


### PR DESCRIPTION
    Error: windows\ansi_reader.go:198:47: conversion from uint16 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)
    Error: windows\ansi_reader.go:201:9: conversion from uint16 to string yields a string of one rune, not a string of digits (did you mean fmt.Sprint(x)?)