### PR TITLE
windows: keyToString(): fix string conversion (for real)

### DIFF
--- a/windows/ansi_reader.go
+++ b/windows/ansi_reader.go
@@ -9,7 +9,6 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"strconv"
 	"strings"
 	"unsafe"
 
@@ -196,10 +195,10 @@ func keyToString(keyEvent *winterm.KEY_EVENT_RECORD, escapeSequence []byte) stri
 
 	// <Alt>+Key generates ESC N Key
 	if !control && alt {
-		return ansiterm.KEY_ESC_N + strings.ToLower(strconv.Itoa(int(keyEvent.UnicodeChar)))
+		return ansiterm.KEY_ESC_N + strings.ToLower(string(rune(keyEvent.UnicodeChar)))
 	}
 
-	return strconv.Itoa(int(keyEvent.UnicodeChar))
+	return string(rune(keyEvent.UnicodeChar))
 }
 
 // formatVirtualKey converts a virtual key (e.g., up arrow) into the appropriate ANSI string.

--- a/windows/ansi_reader_test.go
+++ b/windows/ansi_reader_test.go
@@ -1,0 +1,24 @@
+//go:build windows
+// +build windows
+
+package windowsconsole
+
+import (
+	"testing"
+
+	"github.com/Azure/go-ansiterm"
+	"github.com/Azure/go-ansiterm/winterm"
+)
+
+func TestKeyToString(t *testing.T) {
+	ke := &winterm.KEY_EVENT_RECORD{
+		ControlKeyState: winterm.LEFT_ALT_PRESSED,
+		UnicodeChar:     65, // capital A
+	}
+
+	const expected = ansiterm.KEY_ESC_N + "a"
+	out := keyToString(ke, nil)
+	if out != expected {
+		t.Errorf("expected %s, got %s", expected, out)
+	}
+}


### PR DESCRIPTION
- fixes https://github.com/moby/term/pull/39

I must've been sleeping while writing 2ce69ef9b005eada3413f37c304c34c4bd1f2753 (https://github.com/moby/term/pull/39), because while it "fixed" the error, the intent here obviously is to return the actual character, not the number ':-)