### PR TITLE
deprecate ErrInvalidState

### DIFF
--- a/term.go
+++ b/term.go
@@ -14,6 +14,8 @@ import (
 )
 
 // ErrInvalidState is returned if the state of the terminal is invalid.
+//
+// Deprecated: ErrInvalidState is no longer used.
 var ErrInvalidState = errors.New("Invalid terminal state")
 
 // State represents the state of the terminal.
@@ -55,7 +57,7 @@ func IsTerminal(fd uintptr) bool {
 // to a previous state.
 func RestoreTerminal(fd uintptr, state *State) error {
 	if state == nil {
-		return ErrInvalidState
+		return errors.New("invalid terminal state")
 	}
 	return tcset(fd, &state.termios)
 }


### PR DESCRIPTION
- relates to https://github.com/moby/moby/pull/2954

This error was introduced in https://github.com/moby/moby/commit/aa68656cd3aefe2a64dc259e8d19c72010e4f85b (https://github.com/moby/moby/pull/2954), returned on Unix only, but was never used as a sentinel value anywhere. It doesn't appear to be used anywhere outside of this package, but let's deprecate it first before removing.
