### PR TITLE
gha: update actions/setup-go@v5, actions/checkout@v4, golangci-lint to v1.62.2, test against go1.22, go1.23 (latest, latest -1)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.platform }}
     steps:
     - name: Install Go ${{ matrix.go }}
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
         go-version: ${{ matrix.go }}
     - name: Checkout code

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        go: ["1.18.x", "1.19.x", "1.20.x"]
+        go: ["1.18.x", "1.22.x", "1.23.x"]
         platform: [ubuntu-latest, windows-latest, macos-latest]
     runs-on: ${{ matrix.platform }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,14 @@ jobs:
       with:
         go-version: ${{ matrix.go }}
     - name: Checkout code
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
     - name: Test
       run: go test -v ./...
   lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: go mod tidy
         run: |
           go mod tidy

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,8 @@ jobs:
           git diff --exit-code
       - name: Lint
         run: |
-          docker run --rm -v `pwd`:/go/src/github.com/moby/term -w /go/src/github.com/moby/term \
-            golangci/golangci-lint:v1.50.1 golangci-lint run --disable-all -v \
-            -E govet -E misspell -E gofmt -E ineffassign -E revive
+          docker run --rm -v ./:/go/src/github.com/moby/term -w /go/src/github.com/moby/term \
+            golangci/golangci-lint:v1.62.2 golangci-lint run -v \
+            -E gofmt \
+            -E misspell \
+            -E revive

--- a/term_test.go
+++ b/term_test.go
@@ -86,33 +86,33 @@ func TestSetWinsize(t *testing.T) {
 
 func TestGetFdInfo(t *testing.T) {
 	tty := newTTYForTest(t)
-	inFd, isTerminal := GetFdInfo(tty)
+	inFd, isTerm := GetFdInfo(tty)
 	if inFd != tty.Fd() {
 		t.Errorf("expected: %d, got: %d", tty.Fd(), inFd)
 	}
-	if !isTerminal {
-		t.Error("expected isTerminal to be true")
+	if !isTerm {
+		t.Error("expected file-descriptor to be a terminal")
 	}
 	tmpFile := newTempFile(t)
-	inFd, isTerminal = GetFdInfo(tmpFile)
+	inFd, isTerm = GetFdInfo(tmpFile)
 	if inFd != tmpFile.Fd() {
 		t.Errorf("expected: %d, got: %d", tty.Fd(), inFd)
 	}
-	if isTerminal {
-		t.Error("expected isTerminal to be false")
+	if isTerm {
+		t.Error("expected file-descriptor to not be a terminal")
 	}
 }
 
 func TestIsTerminal(t *testing.T) {
 	tty := newTTYForTest(t)
-	isTerminal := IsTerminal(tty.Fd())
-	if !isTerminal {
-		t.Fatalf("expected isTerminal to be true")
+	isTerm := IsTerminal(tty.Fd())
+	if !isTerm {
+		t.Error("expected file-descriptor to be a terminal")
 	}
 	tmpFile := newTempFile(t)
-	isTerminal = IsTerminal(tmpFile.Fd())
-	if isTerminal {
-		t.Fatalf("expected isTerminal to be false")
+	isTerm = IsTerminal(tmpFile.Fd())
+	if isTerm {
+		t.Error("expected file-descriptor to not be a terminal")
 	}
 }
 
@@ -135,7 +135,11 @@ func TestSaveState(t *testing.T) {
 func TestDisableEcho(t *testing.T) {
 	tty := newTTYForTest(t)
 	state, err := SetRawTerminal(tty.Fd())
-	defer RestoreTerminal(tty.Fd(), state)
+	defer func() {
+		if err := RestoreTerminal(tty.Fd(), state); err != nil {
+			t.Error(err)
+		}
+	}()
 	if err != nil {
 		t.Error(err)
 	}

--- a/term_unix.go
+++ b/term_unix.go
@@ -81,7 +81,7 @@ func setRawTerminal(fd uintptr) (*State, error) {
 	return makeRaw(fd)
 }
 
-func setRawTerminalOutput(fd uintptr) (*State, error) {
+func setRawTerminalOutput(uintptr) (*State, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
### tests: rename vars that shadowed package func and unhandled error

Also update some failure messages.

### setRawTerminalOutput: remove parameter name (revive)

    term_unix.go:84:27: unused-parameter: parameter 'fd' seems to be unused, consider removing or renaming it as _ (revive)
    func setRawTerminalOutput(fd uintptr) (*State, error) {
                              ^

- gha: update golangci-lint to v1.62.2 and enable default linters
- gha: update actions/setup-go@v5
- gha: update actions/checkout@v4
- gha: test against go1.22, go1.23 (latest, latest -1)